### PR TITLE
Update README to use new yarn global command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This project uses a monorepo and yarn workspaces, you will need to have yarn ins
 First, install [Yeoman](http://yeoman.io) and generator-ls-iwa using [yarn](https://yarnpkg.com/en/docs/install) (we assume you have pre-installed [node.js](https://nodejs.org/)).
 
 ```bash
-yarn install -g yo
-yarn install -g generator-ls-iwa
+yarn global add yo generator-ls-iwa
 ```
 
 Then generate your new project:

--- a/generators/app/templates/package.json.ejs
+++ b/generators/app/templates/package.json.ejs
@@ -15,8 +15,8 @@
     "url": "<%= gitUrl %>"
   },<% } %>
   "scripts": {
-    "lint": "eslint ./packages/*/src --ext .js,.jsx",
-    "lint:fix": "eslint ./packages/*/src --fix --ext .js,.jsx",
+    "lint": "eslint \"./packages/*/src/**/*.{js,jsx}\"",
+    "lint:fix": "yarn run lint --fix",
     "storybook": "start-storybook -p 9001 -c ./.storybook"
   },
   "dependencies": {

--- a/generators/iwa/templates/src/lib.js
+++ b/generators/iwa/templates/src/lib.js
@@ -10,5 +10,5 @@ import saga from './redux/sagas';
 export default Index;
 export {
   reducer,
-  saga
+  saga,
 };

--- a/generators/iwa/templates/src/pages/index.js
+++ b/generators/iwa/templates/src/pages/index.js
@@ -1,3 +1,3 @@
 import React from 'react';
 
-export default () => <h1>Hello World</h1>
+export default () => (<h1>Hello World</h1>);

--- a/generators/iwa/templates/src/redux/sagas/index.js
+++ b/generators/iwa/templates/src/redux/sagas/index.js
@@ -1,4 +1,5 @@
+import { take } from 'redux-saga/effects';
 
-export default function*() {
-  return;
+export default function* () {
+  yield take('NOTHING');
 }

--- a/generators/prelude/templates/common/src/routing/Link.js
+++ b/generators/prelude/templates/common/src/routing/Link.js
@@ -14,9 +14,10 @@ export default class Link extends PureComponent {
       to,
       ...props
     } = this.props;
+    const { context } = this;
 
-    if (this.context.iwaRouter) {
-      to = this.context.iwaRouter.resolve(this.props.to);
+    if (context.iwaRouter) {
+      to = context.iwaRouter.resolve(props.to);
     }
 
     return <ReactLink {...props} to={to} />;

--- a/generators/prelude/templates/common/src/routing/Route.js
+++ b/generators/prelude/templates/common/src/routing/Route.js
@@ -14,9 +14,10 @@ export default class Route extends PureComponent {
       path,
       ...props
     } = this.props;
+    const { context } = this;
 
-    if (this.context.iwaRouter) {
-      path = this.context.iwaRouter.resolve(path);
+    if (context.iwaRouter) {
+      path = context.iwaRouter.resolve(path);
     }
 
     return <ReactRoute {...props} path={path} />;

--- a/generators/prelude/templates/common/src/routing/Router.js
+++ b/generators/prelude/templates/common/src/routing/Router.js
@@ -14,15 +14,17 @@ class Router extends Component {
   };
 
   getChildContext() {
+    const { router } = this.props;
     return {
-      iwaRouter: this.props.router,
+      iwaRouter: router,
     };
   }
 
   render() {
+    const { children, history } = this.props;
     return (
-      <ReactRouter history={this.props.history}>
-        {this.props.children}
+      <ReactRouter history={history}>
+        {children}
       </ReactRouter>
     );
   }


### PR DESCRIPTION
Newer versions of yarn disallow npm `install -g` syntax and force you to use `global add`